### PR TITLE
Better support for Grow built-in fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,12 +101,6 @@ PageAbout
 PageGallery
 ```
 
-### Built-in fields
-
-Certain built-in fields are specially named in Grow, such as `$title` and `$path`. Kintaro does not support special characters in the field names. To be able to use the built in fields end the field name in Kintaro with an underscore.
-
-For example, a field named `path_` in Kintaro will be converted to `$path` when downloaded to the Grow pod.
-
 ### Translations
 
 Kintaro supports field translation. Simply mark a field as **"translatable"** within the schema editor and the field will be available for translation. When content is synchronized to Grow, the field name is suffixed with `@` – indicating it should be extracted for translation. Content managed in Kintaro can then be extracted per the normal translation process with Grow – leveraging PO files and external translators.

--- a/README.md
+++ b/README.md
@@ -101,6 +101,12 @@ PageAbout
 PageGallery
 ```
 
+### Built-in fields
+
+Certain built-in fields are specially named in Grow, such as `$title` and `$path`. Kintaro does not support special characters in the field names. To be able to use the built in fields end the field name in Kintaro with an underscore.
+
+For example, a field named `path_` in Kintaro will be converted to `$path` when downloaded to the Grow pod.
+
 ### Translations
 
 Kintaro supports field translation. Simply mark a field as **"translatable"** within the schema editor and the field will be available for translation. When content is synchronized to Grow, the field name is suffixed with `@` – indicating it should be extracted for translation. Content managed in Kintaro can then be extracted per the normal translation process with Grow – leveraging PO files and external translators.

--- a/kintaro/kintaro.py
+++ b/kintaro/kintaro.py
@@ -100,7 +100,12 @@ class KintaroPreprocessor(_GoogleServicePreprocessor):
 
     def _parse_field(self, key, value, field_data):
         # Convert Kintaro keys to Grow built-ins.
-        if key in documents.BUILT_IN_FIELDS:
+        if hasattr(documents, 'BUILT_IN_FIELDS'):
+            built_in_fields = documents.BUILT_IN_FIELDS
+        else:
+            # Support older versions of grow.
+            built_in_fields = ['title', 'order']
+        if key in built_in_fields:
             key = '${}'.format(key)
         if field_data['translatable']:
             key = '{}@'.format(key)

--- a/kintaro/kintaro.py
+++ b/kintaro/kintaro.py
@@ -99,10 +99,8 @@ class KintaroPreprocessor(_GoogleServicePreprocessor):
 
     def _parse_field(self, key, value, field_data):
         # Convert Kintaro keys to Grow built-ins.
-        if key == 'title':
-            key = '$title'
-        elif key == 'order':
-            key = '$order'
+        if key.endswith('_'):
+            key = '${}'.format(key[:-1])
         if field_data['translatable']:
             key = '{}@'.format(key)
         return key, value

--- a/kintaro/kintaro.py
+++ b/kintaro/kintaro.py
@@ -2,6 +2,7 @@ from googleapiclient import discovery
 from googleapiclient import errors
 from grow.common import oauth
 from grow.common import utils
+from grow.pods import documents
 from protorpc import messages
 import datetime
 import grow
@@ -99,8 +100,8 @@ class KintaroPreprocessor(_GoogleServicePreprocessor):
 
     def _parse_field(self, key, value, field_data):
         # Convert Kintaro keys to Grow built-ins.
-        if key.endswith('_'):
-            key = '${}'.format(key[:-1])
+        if key in documents.BUILT_IN_FIELDS:
+            key = '${}'.format(key)
         if field_data['translatable']:
             key = '{}@'.format(key)
         return key, value


### PR DESCRIPTION
Instead of doing separate cases for each of the built in values, allow for a trailing `_` to convert to a built in override.

Ex: `title_ -> $title`