### PR TITLE
Fixing paths that are supposed to be overridden in env.

### DIFF
--- a/kintaro/kintaro.py
+++ b/kintaro/kintaro.py
@@ -112,7 +112,7 @@ class KintaroPreprocessor(_GoogleServicePreprocessor):
             self.pod.logger.info('Deleted -> {}'.format(pod_path))
 
     def _fix_path_none(self, key, value):
-        if self._env_regex_match.search(key):
+        if self._env_regex_match and self._env_regex_match.search(key):
             if key.startswith(('path', '$path')) and value is None:
                 return ''
         return value


### PR DESCRIPTION
If the path is supposed to be overridden in a specific environment it comes from kintaro as a None value but that would just make the serving path default to the blueprint path. Instead need it to be an empty string.