### PR TITLE
'Published' state using the grow path with environment tagging and boolean field.

### DIFF
--- a/kintaro/kintaro.py
+++ b/kintaro/kintaro.py
@@ -345,6 +345,11 @@ class KintaroPreprocessor(_GoogleServicePreprocessor):
                             binding.collection, filename)
                         value[idx] = self.pod.get_doc(
                             content_path, locale=locale)
+                        # Create the doc if it does not exist.
+                        # Prevent dependency problems when new docs
+                        # that do not exist yet because of import order.
+                        if not value[idx].exists:
+                            value[idx].write()
                         break
         elif 'schema_fields' in field_data:
             names_to_schema_fields = self._regroup_schema(

--- a/kintaro/kintaro.py
+++ b/kintaro/kintaro.py
@@ -330,6 +330,7 @@ class KintaroPreprocessor(_GoogleServicePreprocessor):
                 if field_data['type'] == 'BooleanField':
                     if value == True:
                         raise RemoveValueError()
+                    return None
 
                 # For a tagged environment, if the value is null it falls back.
                 if value is None:

--- a/kintaro/kintaro.py
+++ b/kintaro/kintaro.py
@@ -506,15 +506,20 @@ class KintaroPreprocessor(_GoogleServicePreprocessor):
     def download_entries(self, repo_id, collection_id, project_id,
                          kintaro_locale=None, document_id=None, key=None,
                          slugify_key=None):
+        # See kintaro/content/protos/document.proto : SearchRequest
         body = {
             'repo_id': repo_id,
             'collection_id': collection_id,
             'project_id': project_id,
             'document_id': document_id,
+            # See kintaro/content/protos/search.proto : ResultOptions
             'result_options': {
+                'limit': 1000,
+                'locale': kintaro_locale,
+                # TODO: Allow for pagination of requests?
+                # 'offset': 1001
                 'return_json': True,
                 'return_schema': True,
-                'locale': kintaro_locale,
             }
         }
         try:
@@ -677,7 +682,7 @@ class KintaroPreprocessor(_GoogleServicePreprocessor):
         # Handle deleted.
         for pod_path in self._removed:
             if pod_path in self._in_use:
-                self.pod.logger.info('Skipping delete for in use reference -> {}'.format(pod_path))
+                self.pod.logger.info('Skipping delete for in-use reference -> {}'.format(pod_path))
                 continue
             self.pod.delete_file(pod_path)
             self.pod.logger.info('Deleted -> {}'.format(pod_path))

--- a/kintaro/kintaro.py
+++ b/kintaro/kintaro.py
@@ -349,7 +349,7 @@ class KintaroPreprocessor(_GoogleServicePreprocessor):
                         # Prevent dependency problems when new docs
                         # that do not exist yet because of import order.
                         if not value[idx].exists:
-                            value[idx].write()
+                            value[idx].write(fields={})
                         break
         elif 'schema_fields' in field_data:
             names_to_schema_fields = self._regroup_schema(

--- a/kintaro/kintaro.py
+++ b/kintaro/kintaro.py
@@ -522,6 +522,14 @@ class KintaroPreprocessor(_GoogleServicePreprocessor):
                 'return_schema': True,
             }
         }
+
+        download_message = 'Downloading documents from {collection} in the {locale} locale'
+        if kintaro_locale is None:
+            download_message = 'Downloading documents from {collection}'
+        self.pod.logger.info(
+            download_message.format(
+                collection=collection_id, locale=kintaro_locale))
+
         try:
             resp = self.service.documents().searchDocuments(body=body).execute()
         except ssl.SSLError:


### PR DESCRIPTION
Added the ability to have a boolean 'published' style control in kintaro. Requires a `path_env_prod` style Boolean field in kintaro. If the value is false the page is hidden in the production build but still available in the dev and staging environments.

Also fixing the cleanup for removed documents to no remove documents that are in use in during the import.

Fixed the 'missing' document error for kintaro docs that have not been imported yet by creating stub files for missing references.