### PR TITLE
Update libraries to match the Grow ones

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
         'kintaro',
     ],
     install_requires=[
-        'google-api-python-client==1.6.2',
-        'python-slugify==3.0.2',
+        'google-api-python-client==1.9.3',
+        'python-slugify==4.0.0',
     ],
 )


### PR DESCRIPTION
Update google-api-python-client and python-slugify to match Grow versions as per https://github.com/grow/grow/blob/main/Pipfile

Fix #33