### PR TITLE
Validate base_value

### DIFF
--- a/kintaro/kintaro.py
+++ b/kintaro/kintaro.py
@@ -108,14 +108,14 @@ class GroupedEntry(object):
         final_data = copy.deepcopy(original_data)
         for field, value in new_data.items():
             localized_field = '{}@{}'.format(field, locale)
-            base_value = original_data[field]
+            base_value = original_data.get(field)
 
             if isinstance(value, dict):
                 if GroupedEntry.is_document_reference(value):
                     final_data[localized_field] = value
-                else:
+                elif base_value is not None:
                     final_data[field] = GroupedEntry.merge_data(
-                        original_data[field], value, locale)
+                        base_value, value, locale)
             elif isinstance(value, list):
                 new_value = GroupedEntry.merge_lists(base_value, value, locale)
                 if base_value != new_value:


### PR DESCRIPTION
Validate that base_value is not None before calling the recursive function.

If the value is None, in the next call of the function the line `base_value = original_data[field]` will fail with 

```
  File "/code/example/venv/lib/python3.9/site-packages/grow/pods/pods.py", line 869, in preprocess
    preprocessor.run(build=build)
  File "/code/example/extensions/kintaro/kintaro.py", line 688, in run
    entries_with_bindings = self.download_and_group_entries(self.config.bind)
  File "/code/example/extensions/kintaro/kintaro.py", line 582, in download_and_group_entries
    grouped_entries = self._group_entries(
  File "/code/example/extensions/kintaro/kintaro.py", line 265, in _group_entries
    document.add_field_data(fields, locale=locale)
  File "/code/example/extensions/kintaro/kintaro.py", line 153, in add_field_data
    self._fields = GroupedEntry.merge_data(
  File "/code/example/extensions/kintaro/kintaro.py", line 117, in merge_data
    final_data[field] = GroupedEntry.merge_data(
  File "/code/example/extensions/kintaro/kintaro.py", line 117, in merge_data
    final_data[field] = GroupedEntry.merge_data(
  File "/code/example/extensions/kintaro/kintaro.py", line 111, in merge_data
    base_value = original_data[field]
TypeError: 'NoneType' object is not subscriptable
```