### PR TITLE
Fix localized pages

### DIFF
--- a/kintaro/kintaro.py
+++ b/kintaro/kintaro.py
@@ -352,9 +352,13 @@ class KintaroPreprocessor(_GoogleServicePreprocessor):
             for idx in range(len(value)):
                 if not value[idx]:
                     continue
+                localized_coll_field = next(
+                    (k for k in value[idx].keys() if k.startswith('collection_id@')),
+                    ''
+                )
+                coll_field = localized_coll_field or 'collection_id'
                 for binding in self.config.bind:
-                    if binding.kintaro_collection == value[idx][
-                        'collection_id']:
+                    if binding.kintaro_collection == value[idx].get(coll_field):
                         filename = self._get_basename_from_entry(
                             value[idx], key=binding.key)
                         content_path = os.path.join(
@@ -408,7 +412,12 @@ class KintaroPreprocessor(_GoogleServicePreprocessor):
 
     @staticmethod
     def _get_doc_id(entry):
-        return str(entry['document_id'])
+        localized_doc_field = next(
+            (k for k in entry.keys() if k.startswith('document_id@')),
+            ''
+        )
+        doc_field = localized_doc_field or 'document_id'
+        return str(entry.get(doc_field))
 
     def _get_basename_from_entry(self, entry, key=None, slugify_key=None):
         doc_id = KintaroPreprocessor._get_doc_id(entry)


### PR DESCRIPTION
Localized documents were failing because `collection_id` and `document_id` didn't exist in those documents.

```
Traceback (most recent call last):
  File "/code/google-retail/venv/bin/grow", line 8, in <module>
    sys.exit(main())
  File "/code/google-retail/venv/lib/python3.9/site-packages/grow/cli.py", line 21, in main
    group.grow.main(args=args, prog_name=name)
  File "/code/google-retail/venv/lib/python3.9/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/code/google-retail/venv/lib/python3.9/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/code/google-retail/venv/lib/python3.9/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/code/google-retail/venv/lib/python3.9/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/code/google-retail/venv/lib/python3.9/site-packages/grow/commands/subcommands/preprocess.py", line 41, in preprocess
    pod.preprocess(preprocessor, run_all=run_all, tags=tag, ratelimit=ratelimit)
  File "/code/google-retail/venv/lib/python3.9/site-packages/grow/pods/pods.py", line 878, in preprocess
    preprocessor.run(build=build)
  File "/code/google-retail/extensions/kintaro/kintaro.py", line 692, in run
    self.bind_collection(entries, binding.collection)
  File "/code/google-retail/extensions/kintaro/kintaro.py", line 284, in bind_collection
    fields, unused_body, basename, schema = self._parse_entry(
  File "/code/google-retail/extensions/kintaro/kintaro.py", line 472, in _parse_entry
    key, value = self._parse_field(
  File "/code/google-retail/extensions/kintaro/kintaro.py", line 324, in _parse_field
    value = self._parse_field_deep(key, value, field_data, locale=locale)
  File "/code/google-retail/extensions/kintaro/kintaro.py", line 381, in _parse_field_deep
    value[idx] = self._parse_field_value(
  File "/code/google-retail/extensions/kintaro/kintaro.py", line 405, in _parse_field_value
    clean_value[new_key] = self._parse_field_deep(
  File "/code/google-retail/extensions/kintaro/kintaro.py", line 357, in _parse_field_deep
    if binding.kintaro_collection == value[idx][
KeyError: 'collection_id'
```

Debugging the elements, I noticed that there are some cases where the documents have `collection_id@LOCALE` and  `document_id@LOCALE` instead of the regular `collection_id` and `document_id`.


Ex:

```
{'collection_id@de_de': 'Test', 'document_id@de_de': 6600548687282176, 'repo_id@de_de': 'g6-goog-test'}
```

In those cases, we shouldn't get `collection_id` nor `document_id` keys directly. Instead, we should check if there is a key that contains those strings